### PR TITLE
Make controls independent when multiple player on the same page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videojs-shuttle-controls",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Adds shuttle controls(JKL controls) to video.js",
   "main": "dist/videojs-shuttle-controls.cjs.js",
   "module": "dist/videojs-shuttle-controls.es.js",
@@ -17,8 +17,8 @@
     "clean": "shx rm -rf ./dist ./test/dist",
     "postclean": "shx mkdir -p ./dist ./test/dist",
     "docs": "npm-run-all docs:*",
-    "docs:api": "jsdoc src -g plugins/markdown -r -d docs/api",
     "docs:toc": "doctoc --notitle README.md",
+    "docs:api": "jsdoc src -g plugins/markdown -r -d docs/api",
     "lint": "vjsstandard",
     "server": "karma start scripts/karma.conf.js --singleRun=false --auto-watch",
     "start": "npm-run-all -p server watch",

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -122,18 +122,20 @@ class ShuttleControls extends Plugin {
     const buttonDom = videojs.dom.$('.vjs-play-control');
     const techDom = videojs.dom.$('.vjs-tech');
     const playControlHandler = () => {
-      const hasPaused = videojs.dom.hasClass(techDom.parentNode, 'vjs-paused');
-      const currentPlaybackRate = this.currentPlaybackRate;
-      const isNegativePlaying = this.isPlaying && currentPlaybackRate < 0 && hasPaused;
-      const isNegativePause = !this.isPlaying && currentPlaybackRate < 0 && hasPaused;
-      const isPositivePlaying = this.isPlaying && currentPlaybackRate > 0 && !hasPaused;
-      const isPositivePause = !this.isPlaying && currentPlaybackRate > 0 && hasPaused;
+      if (techDom.parentNode.id == this.player.id) {
+        const hasPaused = videojs.dom.hasClass(techDom.parentNode, 'vjs-paused');
+        const currentPlaybackRate = this.currentPlaybackRate;
+        const isNegativePlaying = this.isPlaying && currentPlaybackRate < 0 && hasPaused;
+        const isNegativePause = !this.isPlaying && currentPlaybackRate < 0 && hasPaused;
+        const isPositivePlaying = this.isPlaying && currentPlaybackRate > 0 && !hasPaused;
+        const isPositivePause = !this.isPlaying && currentPlaybackRate > 0 && hasPaused;
 
-      if (isNegativePlaying || isPositivePlaying) {
-        this._playPause();
-      }
-      if (isNegativePause || isPositivePause) {
-        this._play(currentPlaybackRate);
+        if (isNegativePlaying || isPositivePlaying) {
+          this._playPause();
+        }
+        if (isNegativePause || isPositivePause) {
+          this._play(currentPlaybackRate);
+        }
       }
     };
 


### PR DESCRIPTION
When there are multiple video players on the page, the controls work on both instead of only working on the video player where the controls are triggered.

This fix adds a guard to make sure the only player affected is the one whose controls were activated.